### PR TITLE
ES simulator, API docs, Starting on gRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ mediachain-indexer-dedupe | (Re-)Generate deduplication lookup indexes.
 mediachain-indexer-ingest | Ingest media from local sources or Mediachain API, for search & dedupe.
 mediachain-indexer-web    | Search & dedupe REST API.
 mediachain-indexer-eval   | Evaluate and score models against benchmarks.
-mediachain-indexer-test   | End-to-end demos and tests.
+mediachain-indexer-test   | Demos and tests.
 
 
 ## Getting Started
@@ -31,7 +31,21 @@ $ elasticsearch
 $ pip install git+https://github.com/mediachain/mediachain-indexer.git
 ```
 
-4) Inspect environment variables and adjust as necessary:
+4) Run any of the entry points above to see sub-commands:
+
+```
+$ mediachain-indexer-ingest
+
+USAGE: python mc_ingest.py <function_name>
+
+Available Functions:
+getty_create_dumps...................... Quick and dirty Getty API scraper.
+ingest_bulk_blockchain.................. Ingest media from Mediachain blockchain.
+ingest_bulk_gettydump................... Ingest media from Getty data dumps into Indexer.
+config.................................. Print current environment variables.
+```
+
+5) Inspect environment variables and adjust as necessary:
 
 ```
 $ mediachain-indexer-ingest config
@@ -49,39 +63,46 @@ MC_NUMBER_OF_SHARDS="1"
 
 #### Quick Test
 
-5) Run a basic end-to-end demo:
+6) Run a basic sanity check demo:
 
 ```
-$ mediachain-indexer-test demo_end_to_end
+$ mediachain-indexer-test sanity_check
 ```
 
 #### Full Setup
 
-6) Alternatively, grab small Getty testing dataset:
+7) Alternatively, grab small Getty testing dataset:
 
 ```
 $ GETTY_KEY="<your_getty_key>" mediachain-indexer-ingest getty_create_dumps
 ```
 
-7) Ingest Getty dataset:
+8) Ingest Getty dataset:
 
 ```
-$ mediachain-indexer-ingest ingest_bulk
+$ mediachain-indexer-ingest ingest_bulk_gettydump
 ```
 
-8) Deduplicate ingested media:
+Or, ingest from Mediachain blockchain:
+
+```
+$ mediachain-indexer-ingest ingest_bulk_blockchain
+```
+
+
+9) Deduplicate ingested media:
 
 ```
 $ mediachain-indexer-dedupe dedupe_reindex 
 ```
 
-9) Start REST API server:
+10) Start REST API server:
 
 ```
 $ mediachain-indexer-web web
 ```
 
-10) Query the REST API:
+11) Query the REST API:
 
 Search by text:
 
@@ -100,7 +121,6 @@ $ curl "http://127.0.0.1:23456/search" -d '{"q":"crowd", "limit":5}'
                 "caption": "CANNES, FRANCE - MAY 16:  A policeman watches the crowd in front of the Palais des Festival during the red carpet arrivals of the 'Loving' premiere during the 69th annual Cannes Film Festival on May 16, 2016 in Cannes, France.  (Photo by Tristan Fewings/Getty Images)", 
                 "collection_name": "Getty Images Entertainment", 
                 "date_created": "2016-05-16T00:00:00-07:00", 
-                "dedupe_hsh": "d665691fe66393d81c078ae1ff1467cf18f78070900e23ff87c98704cc007c00", 
                 "editorial_source": "Getty Images Europe", 
                 "keywords": "People Vertical Crowd Watching France Police Force Cannes Film Premiere Premiere Arrival Photography Film Industry Red Carpet Event Arts Culture and Entertainment International Cannes Film Festival Celebrities Annual Event Palais des Festivals et des Congres 69th International Cannes Film Festival Loving - 2016 Film", 
                 "title": "'Loving' - Red Carpet Arrivals - The 69th Annual Cannes Film Festival"
@@ -128,7 +148,6 @@ $ curl "http://127.0.0.1:23456/search" -d '{"q_id":"data:image/png;base64,iVBORw
                 "caption": "test", 
                 "collection_name": "test", 
                 "date_created": "2016-05-31T17:41:06.929234", 
-                "dedupe_hsh": "3e600f30039800ee003f020cfde03e000e03b800cf9f03ef88f7c63bf30cf980", 
                 "editorial_source": "", 
                 "keywords": "test", 
                 "title": "Crowd of people walking"
@@ -156,7 +175,6 @@ $ curl "http://127.0.0.1:23456/search" -d '{"q_id":"getty_1234", "limit":5, "ind
                 "caption": "test caption",
                 "collection_name": "test collection name",
                 "date_created": "2016-06-01T15:21:57.796894",
-                "dedupe_hsh": "3e600f30039800ee003f020cfde03e000e03b800cf9f03ef88f7c63bf30cf980",
                 "editorial_source": "test editorial source",
                 "keywords": "test keywords",
                 "title": "Crowd of People Walking"

--- a/mediachain/indexer/mc_config.py
+++ b/mediachain/indexer/mc_config.py
@@ -7,6 +7,11 @@ from mc_generic import intget
 
 MC_GETTY_KEY = os.environ.get('MC_GETTY_KEY', '')
 
+## One or more comma-separated RFC-1738 formatted URLs:
+# e.g. MC_ES_URLS = 'http://user:secret@localhost:9200/,https://user:secret@other_host:443/production'
+
+MC_ES_URLS = intget(os.environ.get('MC_ES_URLS', '')) or ''
+
 ## Elasticsearch index & doc type for image docs (identified by Media IDs):
 
 MC_INDEX_NAME = os.environ.get('MC_INDEX_NAME', '') or 'getty_test'
@@ -24,3 +29,12 @@ MC_DOC_TYPE_MID_TO_CID = os.environ.get('MC_DOC_TYPE_MID_TO_CID', '') or 'cluste
 
 MC_INDEX_NAME_CID_TO_CLUSTER = os.environ.get('MC_INDEX_NAME_CID_TO_CLUSTER', '') or 'clustering_baseline_cid_to_cluster'
 MC_DOC_TYPE_CID_TO_CLUSTER = os.environ.get('MC_DOC_TYPE_CID_TO_CLUSTER', '') or 'clusters'
+
+
+## Used for ingesting from blockchain:
+
+MC_AWS_ACCESS_KEY_ID = os.environ.get('MC_AWS_ACCESS_KEY_ID', '') or ''
+MC_AWS_SECRET_ACCESS_KEY = os.environ.get('MC_AWS_SECRET_ACCESS_KEY', '') or ''
+MC_REGION_NAME = os.environ.get('MC_REGION_NAME', '') or ''   #AWS region of DynamoDB instance           
+MC_ENDPOINT_URL = os.environ.get('MC_ENDPOINT_URL', '') or '' #AWS endpoint of DynamoDB instance
+

--- a/mediachain/indexer/mc_dedupe.py
+++ b/mediachain/indexer/mc_dedupe.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__doc__ = \
 """
 Run dedupe on all ingested media, to generate two lookup tables:
 
@@ -88,6 +87,18 @@ class model_reps_baseline_ng(object):
     """
     Crude image-matching model. Slightly higher recall than `baseline` model.
     Does approximate matching of engineered feature hashes.
+    
+    Attempts to approximate hamming-distance nearest neighbors retrieval from the
+    Lucene / Elasticsearch inverted index. 
+
+    Details:
+        Word-ngrams are simulated by taking patches of 2d boolean array output by the hashing function
+        and converting these "words" to numbers. These numbers are inserted into each image document.
+        The documents are queried using the Lucene / ElasticSearch multiterm tf-idf querying method
+        via queries of the form: "{"query": {"bool": {"should": [ terms_list ] } } }".
+    
+    See Also:
+        `mc_eval.ScoringTFIDF`
     """
     
     def img_to_hsh_bools(self, img_data_uri = False, img_fn = False, hash_size = 16):

--- a/mediachain/indexer/mc_eval.py
+++ b/mediachain/indexer/mc_eval.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__doc__ = \
 """
-Evaluate dedupe and search models against labeled datasets.
+Evaluate dedupe and search models against labeled datasets. Do hyper-parameter tuning.
 
-Starting with:
+Evaluation types:
    - Precision @ k for search.
    - Precision-recall-curve for dedupe.
 """
@@ -18,7 +17,7 @@ import matplotlib.pyplot as plt
 
 import mc_ingest
 import mc_dedupe
-from mc_generic import group, setup_main, raw_input_enter, download_streamed, tcache
+from mc_generic import group, setup_main, raw_input_enter, download_streamed, tcache, pretty_print
 from random import sample
 from os import mkdir, listdir, makedirs
 from os.path import exists
@@ -100,6 +99,9 @@ def iter_ukbench(max_num = 0,
                             )
                 
                 hh['image_thumb'] = d2
+
+            #number of instances of this semantic object:
+            hh['num_instances_this_object'] = 4 
             
             yield hh
 
@@ -117,7 +119,7 @@ def eval(max_num = 500,
     """
     Main evaluation script.
     """
-
+    
     index_name = 'eval_index'
     doc_type = 'eval_doc'
 
@@ -144,9 +146,12 @@ def eval(max_num = 500,
                     '_index': index_name,
                     '_type': doc_type,
                     }
-
+            
             xdoc.update(hh)
-                        
+            
+            for x in rr:
+                assert x['num_instances_this_object'] > 1.0,'Dataset needs to have multiple instances of each object.'
+            
             yield xdoc
 
     print 'INSERTING...'
@@ -175,9 +180,7 @@ def eval(max_num = 500,
     dedupe_prob = {}
 
     done = {}
-    
-    all_ids = set([x['_id'] for x in iter_ukbench()])
-    
+        
     for rep_model_name in rep_model_names:
 
         print 'STARTING',rep_model_name
@@ -204,17 +207,18 @@ def eval(max_num = 500,
         dedupe_true[rep_model_name] = []
         dedupe_prob[rep_model_name] = []
 
-        # Insert fake zero as shown here: https://github.com/scikit-learn/scikit-learn/issues/4223
+        # Insert fake zero as shown here? Don't think this actually does much to solve the stability
+        #  problems with the P/R curve:
+        #  https://github.com/scikit-learn/scikit-learn/issues/4223
+        
         dedupe_true[rep_model_name].append(0)
         dedupe_prob[rep_model_name].append(0.0)
         
-        for c,hh in enumerate(iter_ukbench(num_queries, do_img_data = False)):
+        for c,hh in enumerate(the_gen(num_queries, do_img_data = False)):
             
             group_num = hh['group_num']
             
             query = rep_model.img_to_es_query(img_fn = hh['fn'])
-            
-            #print query
             
             rr = es.search(index = index_name,
                            doc_type = doc_type,
@@ -225,38 +229,36 @@ def eval(max_num = 500,
                            )
             
             rr = rr['hits']['hits']
-            
+
             #print ('GOT','query-(id,grp):',(hh['_id'],group_num),'result-(id,grp):',[(x['_id'],x['fields']['group_num'][0]) for x in rr])
             
             at_4 = len([1
                         for x
                         in rr[:4]
                         if (x['fields']['group_num'][0] == hh['group_num']) and (x['_id'] != hh['_id'])
-                        ]) / 3.0
+                        ]) / (x['num_instances_this_object'] - 1.0)
             at_10 = len([1
                          for x
                          in rr[:10]
                          if (x['fields']['group_num'][0] == hh['group_num']) and (x['_id'] != hh['_id'])
-                         ]) / 3.0
+                         ]) / (x['num_instances_this_object'] - 1.0)
             at_50 = len([1
                          for x
                          in rr[:50]
                          if (x['fields']['group_num'][0] == hh['group_num']) and (x['_id'] != hh['_id'])
-                         ]) / 3.0
+                         ]) / (x['num_instances_this_object'] - 1.0)
 
             p_at_k[rep_model_name]['at_04'] += at_4
             p_at_k[rep_model_name]['at_10'] += at_10
             p_at_k[rep_model_name]['at_50'] += at_50
-
+            
             #print 'at_4',at_4,'at_10',at_10,'at_50',at_50
 
             #if at_4:
             #    raw_input_enter()
-
-
+            
+            
             ### Dedupe stuff:
-
-            unseen_ids = all_ids.copy()
 
             zrr = rr[:]
             shuffle(zrr)
@@ -266,8 +268,6 @@ def eval(max_num = 500,
                 #if cc % 50 == 0:
                 #    print cc
                 
-                unseen_ids.discard(hh2['_id'])
-
                 if (ignore_self) and (hh2['_id'] == hh['_id']):
                     continue
 
@@ -299,18 +299,6 @@ def eval(max_num = 500,
                 dedupe_true[rep_model_name].append(label)
                 dedupe_prob[rep_model_name].append(hh2['_score'])
             
-            if False:
-                for xid in unseen_ids:
-                    if (int(xid) % 4) == (int(hh['_id']) % 4):
-                        label = 1
-                    else:
-                        label = 0
-
-                    if xid == hh['_id']:
-                        continue
-
-                    dedupe_true[rep_model_name].append(label)
-                    dedupe_prob[rep_model_name].append(0.0)
                 
                 
             print c, rep_model_name, p_at_k[rep_model_name]
@@ -395,9 +383,553 @@ def eval(max_num = 500,
     print 'PRECISION_@_K:',[(mm,[(x,100 * y / float(num_queries)) for x,y in zz.items()]) for mm,zz in p_at_k.items()]
         
     print 'DONE'
+
+
+from collections import Counter
+from math import sqrt, log, floor, ceil
+
+import struct
+
+
+class LuceneSmallFloat():
+    """
+    Emulate Lucene's `SmallFloat`.
     
+    See: https://lucene.apache.org/core/4_3_0/core/org/apache/lucene/util/SmallFloat.html
+    """
+    
+    @classmethod
+    def floatToRawIntBits(cls, b):
+        'Simulate Java library function - convert ieee 754 floating point number to integer:'
+        return struct.unpack('>l', struct.pack('>f', b))[0]
+
+    @classmethod
+    def intBitsToFloat(cls, b):
+        'Simulate Java library function - convert integer to ieee 754 floating point'
+        if (b < 2147483647) or (b > -2147483648):
+            return struct.unpack('>f', struct.pack('>l', b))[0]
+        else:
+            assert False,'todo?'
+            #return struct.unpack('d', struct.pack('Q', int(bin(b), 0)))[0]
+
+    @classmethod
+    def byteToFloat(cls, b, numMantissaBits, zeroExp):
+        'Converts an 8 bit float to a 32 bit float.'
+        if (b == 0):
+            return 0.0
+        bits = (b & 0xff) << (24 - numMantissaBits)
+        bits += (63 - zeroExp) << 24
+        return cls.intBitsToFloat(bits)
+
+    @classmethod
+    def floatToByte(cls, f, numMantissaBits, zeroExp):
+        'Converts an 8 bit float to a 32 bit float.'
+        
+        bits = cls.floatToRawIntBits(f)
+        smallfloat = bits >> (24 - numMantissaBits)
+
+        if (smallfloat <= ((63 - zeroExp) << numMantissaBits)):
+            return (bits <= 0) and 0 or 1
+
+        if (smallfloat >= ((63 - zeroExp) << numMantissaBits) + 0x100):
+            return -1
+
+        return smallfloat - ((63 - zeroExp) << numMantissaBits)
+    
+    @classmethod
+    def floatToByte315(cls, f):
+        'Simulate Lucene function.'
+        
+        return cls.floatToByte(f, numMantissaBits=3, zeroExp=15)
+        
+        bits = cls.floatToRawIntBits(f)
+        smallfloat = bits >> (24 - 3)
+
+        if (smallfloat <= ((63 - 15) << 3)):
+            return (bits <= 0) and 0 or 1
+
+        if (smallfloat >= ((63 - 15) << 3) + 0x100):
+            return -1
+
+        return smallfloat - ((63 - 15) << 3)
+
+    @classmethod
+    def byte315ToFloat(cls, b):
+        'Simulate Lucene function.'
+
+        return cls.byteToFloat(b, numMantissaBits=3, zeroExp=15)
+        
+        if (b == 0):
+            return 0.0
+        bits = (b & 0xff) << (24 - 3)
+        bits += (63 - 15) << 24
+        return cls.intBitsToFloat(bits)
+
+    @classmethod
+    def byte52ToFloat(cls, b):
+        return cls.byteToFloat(b, numMantissaBits=5, zeroExp=2)
+
+    @classmethod
+    def floatToByte52(cls, f):
+        return cls.floatToByte(f, numMantissaBits=5, zeroExp=2) 
+    
+    @classmethod
+    def float_round_trip_315(cls, x):
+        return cls.byte315ToFloat(cls.floatToByte315(x))
+
+    @classmethod
+    def float_round_trip_52(cls, x):
+        return cls.byte52ToFloat(cls.floatToByte52(x))
+
+    @classmethod
+    def test(cls):
+        ' Test from: http://www.openjems.com/tag/querynorm/'
+        from math import sqrt
+        assert LuceneSmallFloat.float_round_trip_315(1 / sqrt(13)) == 0.25
+        print 'PASSED'
+
+class LuceneScoringClassic():
+    """
+    Emulate Lucene's classic tf-IDF-based relevance scoring formula.
+    """
+    
+    def __init__(self):
+        self.df = Counter()
+        self.num_docs = 0
+        self.docs = {}
+        
+    def add_doc(self,
+                doc,
+                id = False,
+                ):
+        """
+        Args:
+            doc: Dict of form {term: count}
+        """
+        self.df.update({x:1 for x in doc})
+        self.num_docs += 1
+        
+        if id is not False:
+            self.docs[id] = doc
+        
+    def score(self,
+              query,
+              doc,
+              query_boost = 1.0,
+              verbose = False,
+              ):
+        """
+        Attempt to exactly replicate Lucene's classic relevance scoring formula:
+        
+        score(q,d)  =  
+                queryNorm(q)  
+              · coord(q,d)    
+              · ∑ (           
+                    tf(t in d)   
+                  · idf(t)²      
+                  · t.getBoost() 
+                  · norm(t,d)    
+                ) (t in q)    
+    
+        Args:
+            query:  Dict of form {term: count, ...}
+            doc:    Dict of form {term: count, ...}
+
+        See Also:
+            No one quite gets the formula right, but have a look at these:
+            https://www.elastic.co/guide/en/elasticsearch/guide/master/practical-scoring-function.html
+            http://www.openjems.com/tag/querynorm/
+        """
+        
+        assert self.num_docs,'First `add_doc()`.'
+
+        is_hit = len(set(query).intersection(doc)) and True
+
+        if not is_hit:
+            return 0.0
+        
+        ## Computes a score factor based on a term or phrase's frequency in a document:
+        query_norm = 1.0 / sqrt(sum([(1.0 + log(self.num_docs / (self.df.get(term, 0.0) + 1.0))) ** 2
+                                     for term
+                                     in query
+                                     ]))
+
+        if verbose:
+            print 'query_norm',query_norm,'self.num_docs',self.num_docs
+        
+        # Rewards documents that contain a higher percentage of the query terms:
+        coord = len(set(query).intersection(doc)) / float(len(query))
+        
+        xx = 0.0
+        
+        for term in query:
+            ## Term frequency of this term in this document:
+            tf = sqrt(doc.get(term, 0.0))
+            
+            ## Inverse of frequency of this term in all documents:
+            idf  = (1.0 + log(self.num_docs / (self.df.get(term, 0.0) + 1.0))) ** 2
+            
+            ## Query-level boost:
+            boost = query_boost
+            
+            ## Field-length norm (number of terms in field), combined with the field-level boost, if any:
+            
+            if True:
+                ## !!! For our needs, we can just assume field_norm is 1.0:
+                
+                field_norm = 1.0
+                
+            else:
+                ## Full field_norm calculation. Everything here is tricky. Luckily we can ignore it for our needs:
+                
+                field_length = 1 ## See docs / source for details on this. For our query forms, assume 1.
+                
+                field_norm = LuceneSmallFloat.float_round_trip_315(boost / sqrt(field_length))
+            
+            xx += tf * idf * field_norm # * boost + (idf * query_norm)
+            
+            if verbose:
+                print '->tf',tf,'idf(%d,%d)' % (self.num_docs, self.df.get(term,0)),'idf',idf,
+                print 'boost',boost,
+                print 'field_length',field_length,'field_norm',field_norm,'=xx',tf * idf * boost * field_norm
+            
+        rr = xx * query_norm * coord
+
+        #rr = floor(rr * 1e8) / 1e8
+        
+        if verbose:
+            print 'xx',xx,'query_norm',query_norm,'coord',coord,'=',rr
+        #raw_input_enter()
+        
+        return rr
+
+
+class ElasticSearchEmulator():
+    """
+    Attempts to exactly reproduce the particular subset of ES functionality we use.
+    
+    Useful for indexer system design without having to make assuptions about Lucene / ES black-box scoring formulas,
+    for testing, model evaluation, and hyper-parameter optimization.
+    """
+    
+    def __init__(self,
+                 scoring = LuceneScoringClassic(),
+                 *args,
+                 **kw):
+
+        class indices():
+            def exists(self,
+                       *args,
+                        **kw):
+                return False
+            
+            def delete(self,
+                       *args,
+                        **kw):
+                pass
+            
+            def create(self,
+                       index,
+                       body,
+                       *args,
+                        **kw):
+                pass
+            
+            def refresh(self,
+                        index,
+                        *args,
+                        **kw):
+                pass
+        
+        
+        self.indices = indices()
+
+        self.scoring = scoring
+        
+    def index(self,
+              index,
+              doc_type,
+              id,
+              body,
+              *args,
+              **kw):
+        """
+        Accept documents of the form:
+        
+            {'word1':1, 'word2':2, 'word3':3}
+        """
+        assert id
+        assert body
+        
+        terms = {x:y for x,y in body.items() if not x.startswith('_')}
+        
+        self.scoring.add_doc(terms,
+                             id = id,
+                             )
+    
+    def search(self,
+               index,
+               doc_type,
+               body,
+               explain = False,
+               *args,
+               **kw):
+        """
+        Accepts only queries of the form:
+        
+            {'query': {'bool': {'should': [{'term':{'word1':1}}, {'term':{'word2':2}} ] } } } 
+        """
+
+        ## Get query back into same format as docs:
+        
+        qterms = {}
+        for xx in [x['term'] for x in body['query']['bool']['should']]:
+            qterms.update(xx)
+        
+        rh = {'hits':{'hits':[]}}
+        
+        ## Score and sort docs:
+        
+        xx = []
+        for doc_id,doc in self.scoring.docs.iteritems():
+
+            xdoc = doc.copy()
+            xdoc['_id'] = doc_id
+            
+            xx.append((self.scoring.score(qterms,
+                                          doc,
+                                          ),
+                       xdoc
+                       ),
+                      )
+        
+        ## Apparently ES moves stuff around like this:
+        
+        for sc,doc in sorted(xx, reverse = True):
+            
+            h = {'_id':unicode(doc['_id']),
+                 '_type':unicode(doc_type),
+                 '_index':unicode(index),
+                 '_source':doc,
+                 '_score':sc,
+                 }
+            
+            del doc['_id']
+            
+            if explain:
+                h['_explanation'] = {'details':[], 'description':'EMULATOR_NOT_IMPLEMENTED', 'value':sc}
+            
+            rh['hits']['hits'].append(h)
+        
+        return rh
+
+
+def short_ex(rr):
+    """
+    Condense ES explains.
+
+    Note: Quick throw-away function. Ignore.
+    """
+
+    assert False,'WIP'
+    
+    paths = []
+
+    def ex(rr, depth, path):
+        if depth > 2:
+            return
+        #print rr['description'].replace(' ','_').replace('(','{').replace(')','}').replace(':','') + '(',
+        if not rr['details']:
+            path.append('=' + str(rr['value']))
+            paths.append(path)
+
+        if 'of:' in rr['description']:
+            print ' '.join(rr['description'].split()[-2:-1]) + '(',
+        else:
+            print '<<' + rr['description'] + '>>',
+            return
+
+        #print 'func(',
+        for c,a in enumerate(rr['details']):
+            ex(a, depth + 1, path[:] + [str(rr['description'].replace('\x01', '').replace('\x00', ''))[:50]])
+            if c != len(rr['details']) - 1:
+                print ',',
+        print '=',rr['value'],
+        print ')',
+
+    for hit in rr['hits']['hits']:
+        ex(hit['_explanation'], 0, [])
+        print
+        print
+
+    print 
+    print 'PATHS:'
+    
+    for path in paths:
+        print 'path',path
+        
+    raw_input_enter()
+
+    
+def test_scoring_sim(docs = ['the brown fox is nice', 'the house is big', 'nice fox', 'the fish is fat', 'fox'],
+                     query = 'fox is big',
+                     #docs = ['a','b','c','d','e','e'],
+                     #query = 'a b v z',
+                     index_name = 'query_test',
+                     doc_type = 'query_test_doc',
+                     ):
+    """
+    Let's see if we can exactly reproduce the Lucene classic scoring function.
+
+    Run this test to evaluate the simulated index vs real ElasticSearch.
+    """
+    
+    from string import lowercase,letters,digits
+    from random import choice
+    
+    #docs = [choice(lowercase)+choice(lowercase) for x in xrange(10)]
+    #query = ' '.join([choice(docs) for x in xrange(2)])
+
+    print 'DOCS:'
+    for doc in docs:
+        print repr(doc)
+
+    print
+    print 'QUERY:'
+    print repr(query)
+
+    print
+    
+    ## This is optional:
+    
+    qq = {}
+    qq_rev = {}
+    qq_num = [0]
+    
+    def doc_to_term_counts(zz):
+        """
+        Avoid potential problems related to ES analyzers by converting term keys from strings to integer IDs.
+        
+        If you don't want this, just replace with `Counter(zz.split())`.
+        """
+
+        if True:
+            # Disabled, seems it's not needed for our "should match" queries.
+            return Counter(zz.split())
+        else:
+            rh = {}
+            for w,cnt in Counter(zz.split()).items():
+                if w not in qq:
+                    qq_num[0] += 1
+                    qq[w] = qq_num[0]
+                    qq_rev[qq_num[0]] = w
+                rh[qq[w]] = cnt
+            print (zz,'->',{qq_rev[x]:y for x,y in rh.items()})
+            print 'aa',rh
+            return rh
+
+    
+    ## If you want to test the scoring without the full ES emulator:
+
+    if False:    
+        xx = LuceneScoringClassic()
+        
+        for x in docs:
+            #xx.add_doc(Counter(x.split()))
+            xx.add_doc(doc_to_term_counts(x))
+
+        for a,b in list(sorted([xx.score(Counter(query.split()), Counter(x.split()))
+                                for x
+                                in docs
+                                ],
+                               reverse = True)):
+            print 'SCORE',a,b
+
+    
+    ## Try multiple ES versions and compare results:
+    
+    results = []
+    
+    for es in [ElasticSearchEmulator(),
+               mc_ingest.es_connect(),
+               ]:
+
+        print
+        print 'START',es.__class__.__name__
+        
+        if es.indices.exists(index_name):
+            es.indices.delete(index = index_name)
+
+        es.indices.create(index = index_name,
+                          body = {'settings': {'number_of_shards': 1, #must be 1, or scoring has problems.
+                                               'number_of_replicas': 0,
+                                               },
+                                  },
+                          #ignore = 400,
+                          )
+
+        for c,doc in enumerate(docs):
+            es.index(index = index_name,
+                     doc_type = doc_type,
+                     id = str(c),
+                     body = doc_to_term_counts(doc),
+                     )
+        
+        es.indices.refresh(index = index_name)
+        
+        aa = {'query': {'bool': {'should': [{'term': {x:y}} for x,y in doc_to_term_counts(query).items()] } } } 
+        
+        rr = es.search(index = index_name,
+                       doc_type = doc_type,
+                       body = aa,
+                       explain = True,
+                       )
+
+        ## NOTE: Hits with tied scores are returned from ES in unpredictable order. Let's re-sort using IDs as tie-breakers:
+        
+        rr['hits']['hits'] = [c for (a,b),c in sorted([((x['_score'], x['_id']),x) for x in rr['hits']['hits']], reverse=True)]
+        
+        #print pretty_print(rr)
+
+        #short_ex(rr)
+        
+        for hit in rr['hits']['hits']:
+            print '-->score:','%.12f' % hit['_score'],'id:',hit['_id'], 'source:',hit['_source']
+
+        
+        results.append((es.__class__.__name__,
+                        tuple([x['_id'] for x in rr['hits']['hits'] if x['_score'] > 0.0]),
+                        ))
+
+    print
+    print 'FINAL_RESULTS:'
+
+    ml = max([len(x) for x,y in results])
+    
+    first = False
+    any_failed = False
+    for nm, rr in results:
+
+        print '-->',nm.ljust(ml),
+        
+        if first is False:
+            first = rr
+            print 'SAME',
+        elif (first != rr):
+            any_failed = True
+            print 'DIFF',
+        else:
+            print 'SAME',
+
+        print rr
+            
+    assert not any_failed,'FAILED'
+
+    print
+    print 'ALL_PASSED'
 
 functions=['eval',
+           'test_scoring_sim',
            ]
 
 def main():

--- a/mediachain/indexer/mc_generic.py
+++ b/mediachain/indexer/mc_generic.py
@@ -131,6 +131,14 @@ def pretty_print(val,
                  ):
     """
     Pretty print JSON, indenting up to a specified maximum depth.
+
+    Args:
+        val:              JSON input.
+        indent:           Number of additional spaces to indent per layer of depth.
+        max_indent_depth: Beyond this depth in the JSON structure, indentation doesn't get any greater.
+    
+    Use `max_indent_depth` for a middle-ground between no indentation, and excessive
+    indentation of very deep JSON that overflows the width of the screen.
     """
         
     try:

--- a/mediachain/indexer/mc_test.py
+++ b/mediachain/indexer/mc_test.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__doc__ = \
 """
-Testing.
+Testing. Currently a quick end-to-end sanity check.
 """
 
 import datetime
@@ -21,11 +20,11 @@ MC_WEB_HOST = 'http://127.0.0.1:23456'
 TEST_INDEX_NAME = 'mc_test'
 TEST_DOC_TYPE = 'mc_test_image'
 
-def demo_end_to_end(index_name = TEST_INDEX_NAME,
-                    doc_type = TEST_DOC_TYPE,
-                    ):
+def sanity_check(index_name = TEST_INDEX_NAME,
+                 doc_type = TEST_DOC_TYPE,
+                 ):
     """
-    Quick end-to-end demos. WIP while API is being finalized. TODO: full tests.
+    Quick sanity check. WIP while API is being finalized. TODO: full tests.
     
     1. ingest images.
     2. search for images.
@@ -128,9 +127,9 @@ def demo_end_to_end(index_name = TEST_INDEX_NAME,
     print pretty_print(hh)
     assert hh['results'][0]['_id'] == img_id,(5,hh)
 
-    print ('DONE_DEMO')
+    print ('PASSED_SANITY_CHECK')
 
-functions = ['demo_end_to_end',
+functions = ['sanity_check',
              ]
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 tornado==4.3
-tornadoes==2.4.2
 elasticsearch==2.3.0
-python-dateutil==2.4.2
-Pillow==3.2.0
-numpy==1.11.0
 image-match==0.2.1 
-requests==2.10.0
+tornadoes>=2.4.2
+python-dateutil>=2.4.2
+Pillow>=3.2.0
+numpy>=1.11.0
+requests>=2.10.0


### PR DESCRIPTION
Progress toward `Getty -> blockchain -> indexer ingest -> indexer API output` test:
- API Refinements.
- Docs updates.
- WIP setting up artefact ingestion via gRPC.

Indexer model updates:
- ML model refinements.
- Demystifying the Lucene's search relevance scoring function by replicating it - valuable if we continue with the ES inverted index approach. Good for hyper-parameter optimization too. Can now setup testing against a more stable interface.
- Clean up model eval scripts. Generalize eval scripts to handle other datasets.
