### PR TITLE
use aws config from environment or aws cli

### DIFF
--- a/mediachain/indexer/mc_config.py
+++ b/mediachain/indexer/mc_config.py
@@ -30,10 +30,11 @@ MC_DOC_TYPE_CID_TO_CLUSTER = os.environ.get('MC_DOC_TYPE_CID_TO_CLUSTER', '') or
 
 MC_GETTY_KEY = os.environ.get('MC_GETTY_KEY', '') # Getty key, for creating local dump of getty images.
 
-MC_AWS_ACCESS_KEY_ID = os.environ.get('MC_AWS_ACCESS_KEY_ID', '') or ''
-MC_AWS_SECRET_ACCESS_KEY = os.environ.get('MC_AWS_SECRET_ACCESS_KEY', '') or ''
-MC_REGION_NAME = os.environ.get('MC_REGION_NAME', '') or ''   #AWS region of DynamoDB instance.  
-MC_ENDPOINT_URL = os.environ.get('MC_ENDPOINT_URL', '') or '' #AWS endpoint of DynamoDB instance.
+MC_AWS_ACCESS_KEY_ID = os.environ.get('MC_AWS_ACCESS_KEY_ID')
+MC_AWS_SECRET_ACCESS_KEY = os.environ.get('MC_AWS_SECRET_ACCESS_KEY')
+MC_DYNAMO_TABLE_NAME = os.environ.get('MC_DYNAMO_TABLE_NAME', 'Mediachain')
+MC_REGION_NAME = os.environ.get('MC_REGION_NAME')  #AWS region of DynamoDB instance.
+MC_ENDPOINT_URL = os.environ.get('MC_ENDPOINT_URL')  #AWS endpoint of DynamoDB instance.
 
 ## Testing settings:
 

--- a/mediachain/indexer/mc_ingest.py
+++ b/mediachain/indexer/mc_ingest.py
@@ -325,13 +325,15 @@ def ingest_bulk_blockchain(last_block_ref = None,
     from grpc.framework.interfaces.face.face import ExpirationError
 
     from mediachain.datastore.dynamo import set_aws_config
-    
-    set_aws_config({'endpoint_url': 'http://localhost:8000',
-                    'mediachain_table_name': 'Mediachain',
-                    'aws_access_key_id': '',
-                    'aws_secret_access_key': '',
-                    'region_name':'',
-                    })
+    aws_cfg = {'endpoint_url': mc_config.MC_ENDPOINT_URL,
+               'mediachain_table_name': mc_config.MC_DYNAMO_TABLE_NAME,
+               'aws_access_key_id': mc_config.MC_AWS_ACCESS_KEY_ID,
+               'aws_secret_access_key': mc_config.MC_AWS_SECRET_ACCESS_KEY,
+               'region_name': mc_config.MC_REGION_NAME,
+               }
+
+    aws_cfg = dict((k, v) for k, v in aws_cfg.iteritems() if v is not None)
+    set_aws_config(aws_cfg)
     
     def the_gen():
         


### PR DESCRIPTION
- tries to get aws keys & endpoint from env vars.  If they're not
  present, will fallback to using the credentials set with aws cli
- uses the dynamo table in `MC_DYNAMO_TABLE_NAME` env var
  this should be set to `Test` for demo purposes
