### PR TITLE
Update datastore configuration for rpc datastore service

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,17 +73,12 @@ $ mediachain-indexer-ingest config
 
 ## 2. Ingestion Settings:
 
-  # AWS region of DynamoDB instance:
-  MC_REGION_NAME           = None                        <STR>
-  MC_AWS_SECRET_ACCESS_KEY = None                        <STR>
-  MC_AWS_ACCESS_KEY_ID     = None                        <STR>
-  MC_DYNAMO_TABLE_NAME     = 'Mediachain'                <STR>
+  # Mediachain datastore settings:
+  MC_DATASTORE_HOST        = None                        <STR>
+  MC_DATASTORE_PORT_INT    = 10002                       <INT>
 
   # Getty key, for creating local dump of getty images:
   MC_GETTY_KEY             = ''                          <STR>
-
-  # AWS endpoint of DynamoDB instance:
-  MC_ENDPOINT_URL          = None                        <STR>
 
 ## 3. Settings for Automated Tests:
 

--- a/mediachain/indexer/mc_config.py
+++ b/mediachain/indexer/mc_config.py
@@ -51,11 +51,8 @@ cfg = {'1. Model Settings. NOTE - WIP. These settings are not enabled yet.':
            },
        '3. Ingestion Settings':
            {'MC_GETTY_KEY':('', 'Getty key, for creating local dump of getty images'),
-            'MC_AWS_ACCESS_KEY_ID':(None, ''),
-            'MC_AWS_SECRET_ACCESS_KEY':(None, ''),
-            'MC_DYNAMO_TABLE_NAME':('Mediachain', ''),
-            'MC_REGION_NAME':(None, 'AWS region of DynamoDB instance'),
-            'MC_ENDPOINT_URL':(None, 'AWS endpoint of DynamoDB instance'),
+            'MC_DATASTORE_HOST': ('', ''),
+            'MC_DATASTORE_PORT_INT': ('10002', ''),
             'MC_USE_IPFS_INT':(1, 'Use IPFS for image ingestion.'),
            },
        '4. Settings for Automated Tests':

--- a/mediachain/indexer/mc_ingest.py
+++ b/mediachain/indexer/mc_ingest.py
@@ -405,16 +405,15 @@ def ingest_blockchain(last_block_ref = None,
     grpc_errors = (AbortionError, CancellationError, ExpirationError, LocalShutdownError, \
                    NetworkError, RemoteShutdownError, RemoteError)
     
-    from mediachain.datastore.dynamo import set_aws_config
-    aws_cfg = {'endpoint_url': mc_config.MC_ENDPOINT_URL,
-               'mediachain_table_name': mc_config.MC_DYNAMO_TABLE_NAME,
-               'aws_access_key_id': mc_config.MC_AWS_ACCESS_KEY_ID,
-               'aws_secret_access_key': mc_config.MC_AWS_SECRET_ACCESS_KEY,
-               'region_name': mc_config.MC_REGION_NAME,
-               }
-    
-    aws_cfg = dict((k, v) for k, v in aws_cfg.iteritems() if v is not None)
-    set_aws_config(aws_cfg)
+    from mediachain.datastore.rpc import set_rpc_datastore_config
+    store_cfg = {'host': mc_config.MC_DATASTORE_HOST,
+                 'port': mc_config.MC_DATASTORE_PORT_INT
+                 }
+    if not store_cfg['host']:
+        store_cfg['host'] = mc_config.MC_TRANSACTOR_HOST
+
+
+    set_rpc_datastore_config(store_cfg)
     
     def the_gen():
         


### PR DESCRIPTION
This updates the configuration settings for the datastore, since we removed the direct dynamo db access in https://github.com/mediachain/mediachain-client/pull/37

Removes the aws environment variables from `mc_config`, and replaces with `MC_DATASTORE_HOST` and `MC_DATASTORE_PORT_INT`, which are passed to `mediachain.datastore.rpc.set_rpc_datastore_config`

If `MC_DATASTORE_HOST` is not set, uses `MC_TRANSACTOR_HOST`
