### PR TITLE
packaging setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+venv/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+#Ipython Notebook
+.ipynb_checkpoints
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ hyperopt==0.0.2
 #required by hyperopt:
 pymongo==3.2.2
 base58==0.2.2
-#mediachain-client==0.1.0
+mediachain-client==0.1.2
 asteval==0.9.7


### PR DESCRIPTION
This adds a dependency on `mediachain-client==0.1.2`, which I just published to pypi, so we can install the indexer without having to manually install the client project.

Also adds requirements.txt to MANIFEST.in, and adds a gitignore to filter out python packaging cruft.

With this I can run `python setup.py sdist` and then `pip install dist/mediachain-indexer-0.0.10.tar.gz` to install the generated package.  So it should be good to upload to pypi when we're ready to do that.
