### PR TITLE
fixes for blockchain tailing

### DIFF
--- a/mediachain/indexer/mc_ingest.py
+++ b/mediachain/indexer/mc_ingest.py
@@ -340,7 +340,7 @@ def tail_blockchain(via_cli = False):
 
     cur = SimpleClient()
     
-    for art in cur.read_artefacts():
+    for art in cur.get_artefacts():
         print ('ART:',time(),art)
     
 
@@ -366,7 +366,7 @@ def receive_blockchain_into_indexer(last_block_ref = None,
     def the_gen():
         ## Convert from blockchain format to Indexer format:
         
-        for art in cur.read_artefacts(force_exit = via_cli): ## Force exit after loop is complete, if CLI.
+        for art in cur.get_artefacts(force_exit = via_cli): ## Force exit after loop is complete, if CLI.
             
             try:
                 print 'GOT',art.get('type')

--- a/mediachain/indexer/mc_ingest.py
+++ b/mediachain/indexer/mc_ingest.py
@@ -405,14 +405,14 @@ def receive_blockchain_into_indexer(last_block_ref = None,
                 rh['latest_ref'] = base58.b58encode(raw_ref[u'@link'])
 
                 ## TODO - use different created date? Phase out `translatedAt`:
+                xx = None
                 if 'translated_at' in art['meta']:
                     xx = art['meta']['translated_at']
                 elif 'translatedAt' in art['meta']:
                     xx = art['meta']['translatedAt']
-                else:
-                    assert False,'translatedAt'
-                
-                rh['date_created'] = date_parser.parse(xx) 
+
+                if xx is not None:
+                    rh['date_created'] = date_parser.parse(xx)
 
                 rhc = rh.copy()
                 if 'img_data' in rhc:

--- a/mediachain/indexer/mc_simpleclient.py
+++ b/mediachain/indexer/mc_simpleclient.py
@@ -209,11 +209,11 @@ class SimpleClient(object):
     
     def __init__(self,
                  ## Hard Code for now:
-                 datastore_host = '107.23.23.184',
+                 datastore_host = 'facade.mediachain.io',
                  datastore_port = 10002,
-                 transactor_host = '107.23.23.184',
+                 transactor_host = 'facade.mediachain.io',
                  transactor_port = 10001,
-                 use_ipfs = False,
+                 use_ipfs = True,
                  #datastore_host = mc_config.MC_DATASTORE_HOST,
                  #datastore_port = mc_config.MC_DATASTORE_PORT_INT,
                  #transactor_host = mc_config.MC_TRANSACTOR_HOST,
@@ -243,7 +243,7 @@ class SimpleClient(object):
                                            )
         
         set_rpc_datastore_config({'host': datastore_host, 'port': datastore_port})
-        set_ipfs_config({'host': 'http://localhost:8000', 'port': 5001})
+        set_ipfs_config({'host': 'localhost', 'port': 5001})
         set_use_ipfs_for_raw_data(True)
     
     

--- a/mediachain/indexer/mc_simpleclient.py
+++ b/mediachain/indexer/mc_simpleclient.py
@@ -322,8 +322,8 @@ class SimpleClient(object):
                     fetch_images = False,
                     reverse = False,
                     timeout = 600,
-                    force_exit_on_grpc_error = True,
-                    object_type = False
+                    force_exit = True,
+                    object_type = False,
                     ):
         """
         Get Artefacts or Entities from the blockchain.
@@ -412,7 +412,7 @@ class SimpleClient(object):
                 
                 print ('!!!CAUGHT gRPC ERROR',e)
                 
-                if force_exit_on_grpc_error:
+                if force_exit:
                     print ('FORCING EXIT',)
                     from time import sleep
                     import traceback, sys, os

--- a/mediachain/indexer/mc_simpleclient.py
+++ b/mediachain/indexer/mc_simpleclient.py
@@ -401,7 +401,7 @@ class SimpleClient(object):
                         else:
                             continue
                     
-                    yield art
+                    yield obj
                     
                     if (end_id is not False):
                         if obj['data']['_id'] == end_id:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ hyperopt==0.0.2
 #required by hyperopt:
 pymongo==3.2.2
 base58==0.2.2
-mediachain-client==0.1.2
+mediachain-client>=0.1.2
 asteval==0.9.7


### PR DESCRIPTION
This fixes up a few things to get `mediachain-indexer-ingest tail_blockchain` and `mediachain-indexer-ingest receive_blockchain_into_indexer` working.

Mostly just fixes a few variable and method names, and sets the defaults so it tries to connect to the testnet at `facade.mediachain.io`

Also makes the `translatedAt` field optional; we should probably remove that entirely, but I figure the ingestion from the blockchain will probably need a lot of metaschema work in the future, so didn't want to make any big changes now.  This gets it working with the data that's currently in the testnet.
