### PR TITLE
use mc_config vars for SimpleClient

### DIFF
--- a/mediachain/indexer/mc_config.py
+++ b/mediachain/indexer/mc_config.py
@@ -44,10 +44,10 @@ cfg = {'1. Model Settings. NOTE - WIP. These settings are not enabled yet.':
            },
        '3. Ingestion Settings':
            {'MC_GETTY_KEY':('', 'Getty key, for creating local dump of getty images'),
-            'MC_DATASTORE_HOST': ('', 'Datastore host.'),
+            'MC_DATASTORE_HOST': ('facade.mediachain.io', 'Datastore host.'),
             'MC_DATASTORE_PORT_INT': ('10002', 'Datastore port.'),
-            'MC_IPFS_URL': ('http://localhost:8000', 'IPFS URL.'),
-            'MC_IPFS_PORT_INT': ('5000', 'IPFS port.'),
+            'MC_IPFS_URL': ('localhost', 'IPFS host.'),
+            'MC_IPFS_PORT_INT': ('5001', 'IPFS port.'),
             'MC_USE_IPFS_INT':(1, 'Use IPFS for image ingestion.'),
            },
        '4. Settings for Automated Tests':
@@ -56,7 +56,7 @@ cfg = {'1. Model Settings. NOTE - WIP. These settings are not enabled yet.':
             'MC_TEST_DOC_TYPE':('mc_test_image', 'Document type, required for some neighbors models.'),
            },
            '5. Transactor Settings':
-           {'MC_TRANSACTOR_HOST':('', ''),
+           {'MC_TRANSACTOR_HOST':('facade.mediachain.io', 'Mediachain transactor RPC host.'),
             'MC_TRANSACTOR_PORT_INT':('10001', ''),
            },
        }

--- a/mediachain/indexer/mc_simpleclient.py
+++ b/mediachain/indexer/mc_simpleclient.py
@@ -193,17 +193,11 @@ class SimpleClient(object):
     """
     
     def __init__(self,
-                 ## Hard Code for now:
-                 datastore_host = 'facade.mediachain.io',
-                 datastore_port = 10002,
-                 transactor_host = 'facade.mediachain.io',
-                 transactor_port = 10001,
-                 use_ipfs = True,
-                 #datastore_host = mc_config.MC_DATASTORE_HOST,
-                 #datastore_port = mc_config.MC_DATASTORE_PORT_INT,
-                 #transactor_host = mc_config.MC_TRANSACTOR_HOST,
-                 #transactor_port = mc_config.MC_TRANSACTOR_PORT_INT,
-                 #use_ipfs = mc_config.MC_USE_IPFS_INT,
+                 datastore_host = mc_config.MC_DATASTORE_HOST,
+                 datastore_port = mc_config.MC_DATASTORE_PORT_INT,
+                 transactor_host = mc_config.MC_TRANSACTOR_HOST,
+                 transactor_port = mc_config.MC_TRANSACTOR_PORT_INT,
+                 use_ipfs = mc_config.MC_USE_IPFS_INT,
                  ):
         """
         """


### PR DESCRIPTION
removes the hardcoded params to SimpleClient.**init** and sets the correct defaults in mc_config
