### PR TITLE
remove blockchain stream timeout

### DIFF
--- a/mediachain/indexer/mc_simpleclient.py
+++ b/mediachain/indexer/mc_simpleclient.py
@@ -371,20 +371,20 @@ class SimpleClient(object):
             
             try:
                 started = False
-                
-                for obj in self.transactor.canonical_stream(timeout = timeout):
-                    
-                    if (start_id is not False) and (not started):
-                        if obj['data']['_id'] == start_id:
-                            started = True
-                        else:
-                            continue
-                    
-                    yield obj
-                    
-                    if (end_id is not False):
-                        if obj['data']['_id'] == end_id:
-                            break
+                with self.transactor.canonical_stream() as stream:
+                    for obj in stream:
+
+                        if (start_id is not False) and (not started):
+                            if obj['data']['_id'] == start_id:
+                                started = True
+                            else:
+                                continue
+
+                        yield obj
+
+                        if (end_id is not False):
+                            if obj['data']['_id'] == end_id:
+                                break
                     
             
             except grpc_errors as e:

--- a/mediachain/indexer/mc_simpleclient.py
+++ b/mediachain/indexer/mc_simpleclient.py
@@ -300,7 +300,7 @@ class SimpleClient(object):
                     artist_ids = False,
                     fetch_images = False,
                     reverse = False,
-                    timeout = 600,
+                    timeout = None,
                     force_exit = True,
                     object_type = False,
                     ):
@@ -371,7 +371,7 @@ class SimpleClient(object):
             
             try:
                 started = False
-                with self.transactor.canonical_stream() as stream:
+                with self.transactor.canonical_stream(timeout=timeout) as stream:
                     for obj in stream:
 
                         if (start_id is not False) and (not started):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ hyperopt==0.0.2
 #required by hyperopt:
 pymongo==3.2.2
 base58==0.2.2
-mediachain-client>=0.1.2
+mediachain-client>=0.1.6
 asteval==0.9.7
 ujson==1.33


### PR DESCRIPTION
this uses with / as to open the `canonical_stream` from the transactor, and defaults to setting `timeout=None` so we get an infinite stream of events.  It will still close cleanly if you ctrl-c the process, etc.
