### PR TITLE
include `canonical_ref` of blockchain objects in index

### DIFF
--- a/mediachain/indexer/mc_ingest.py
+++ b/mediachain/indexer/mc_ingest.py
@@ -406,7 +406,7 @@ def receive_blockchain_into_indexer(last_block_ref = None,
     def the_gen():
         ## Convert from blockchain format to Indexer format:
         
-        for art in cur.get_artefacts(force_exit = via_cli): ## Force exit after loop is complete, if CLI.
+        for ref, art in cur.get_artefacts(force_exit = via_cli): ## Force exit after loop is complete, if CLI.
             
             try:
                 print 'GOT',art.get('type')
@@ -449,6 +449,7 @@ def receive_blockchain_into_indexer(last_block_ref = None,
                     assert False,('RAW_REF',repr(art)[:500])
                 
                 rh['latest_ref'] = base58.b58encode(raw_ref[u'@link'])
+                rh['canonical_ref'] = ref
 
                 ## TODO - use different created date? Phase out `translatedAt`:
                 xx = None

--- a/mediachain/indexer/mc_simpleclient.py
+++ b/mediachain/indexer/mc_simpleclient.py
@@ -361,7 +361,7 @@ class SimpleClient(object):
                                      object_id = oid,
                                      fetch_images = fetch_images,
                                      )
-                yield obj
+                yield oid, obj
         
         else:
 
@@ -372,7 +372,7 @@ class SimpleClient(object):
             try:
                 started = False
                 with self.transactor.canonical_stream(timeout=timeout) as stream:
-                    for obj in stream:
+                    for ref, obj in stream:
 
                         if (start_id is not False) and (not started):
                             if obj['data']['_id'] == start_id:
@@ -380,7 +380,7 @@ class SimpleClient(object):
                             else:
                                 continue
 
-                        yield obj
+                        yield ref, obj
 
                         if (end_id is not False):
                             if obj['data']['_id'] == end_id:


### PR DESCRIPTION
Depends on https://github.com/mediachain/mediachain-client/pull/82

gets the canonical ref from the updated `canonical_stream` method, and inserts it into the index at the `canonical_ref` key (sibling to `latest_ref`)
