### PR TITLE
only download remote thumbnails if not already cached

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ hyperopt==0.0.2
 #required by hyperopt:
 pymongo==3.2.2
 base58==0.2.2
-mediachain-client>=0.1.7
+mediachain-client>=0.1.8
 asteval==0.9.7
 ujson==1.33


### PR DESCRIPTION
This uses the `open_binary_asset` fn from https://github.com/mediachain/mediachain-client/pull/83 to get a file-like stream of the `thumbnail` asset, if it exists in a blockchain-sourced record.

It will only pull the asset if we haven't already cached the requested size of an image with the same `uri`.  Changes the `cache_image` function a bit, replacing the `image_base64` param with an `image_open_fn` that will return the file-like object, and an `image_origin` that should have the uri.  Saves the md5 of the uri to disk to see if we've already cached it.

Also fixes up a bug that was causing only the first size in `do_sizes` to be written out to disk.

Seems to work well on my VM, tailing from the records in the testnet.
