### PR TITLE
add --disable-catchup flag to receive_blockchain_into_indexer

### DIFF
--- a/mediachain/indexer/mc_ingest.py
+++ b/mediachain/indexer/mc_ingest.py
@@ -833,11 +833,15 @@ def receive_blockchain_into_indexer(last_block_ref = None,
     from mc_simpleclient import SimpleClient
     
     cur = SimpleClient()
-    
+
+    # TODO: replace this flag with a ref to the last known block, once
+    # the client supports seeking back to a known block
+    catchup = ('--disable-catchup' not in sys.argv)
+    print('BLOCKCHAIN_CATCHUP', catchup)
     def the_gen():
         ## Convert from blockchain format to Indexer format:
         
-        for ref, art in cur.get_artefacts(force_exit = via_cli): ## Force exit after loop is complete, if CLI.
+        for ref, art in cur.get_artefacts(catchup_blockchain=catchup, force_exit = via_cli): ## Force exit after loop is complete, if CLI.
             
             try:
                 print 'GOT',art.get('type')

--- a/mediachain/indexer/mc_ingest.py
+++ b/mediachain/indexer/mc_ingest.py
@@ -837,7 +837,6 @@ def receive_blockchain_into_indexer(last_block_ref = None,
     # TODO: replace this flag with a ref to the last known block, once
     # the client supports seeking back to a known block
     catchup = ('--disable-catchup' not in sys.argv)
-    print('BLOCKCHAIN_CATCHUP', catchup)
     def the_gen():
         ## Convert from blockchain format to Indexer format:
         

--- a/mediachain/indexer/mc_simpleclient.py
+++ b/mediachain/indexer/mc_simpleclient.py
@@ -294,6 +294,7 @@ class SimpleClient(object):
     
         
     def get_objects(self,
+                    catchup_blockchain = True, # TODO, replace with last_block_height, once client support is in
                     start_id = False,
                     end_id = False,
                     only_ids = False,
@@ -371,7 +372,7 @@ class SimpleClient(object):
             
             try:
                 started = False
-                with self.transactor.canonical_stream(timeout=timeout) as stream:
+                with self.transactor.canonical_stream(catchup=catchup_blockchain, timeout=timeout) as stream:
                     for ref, obj in stream:
 
                         if (start_id is not False) and (not started):


### PR DESCRIPTION
This adds a flag to disable the blockchain catchup when running `mediachain-indexer-ingest receive_blockchain_into_indexer`.  It will skip the catchup / replay if you pass in the `--disable-catchup` flag.

It will still play back the events from the current (in-progress) block, but that should be much faster than catching up the entire chain.

This is a stop-gap measure until we support catching up until we hit a known block, which needs to be added to the client.
