### PR TITLE
wip - catchup to last known block

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ hyperopt==0.0.2
 #required by hyperopt:
 pymongo==3.2.2
 base58==0.2.2
-mediachain-client>=0.1.8
+mediachain-client>=0.1.10
 asteval==0.9.7
 ujson==1.33


### PR DESCRIPTION
This updates the SimpleClient and `receive_blockchain_into_indexer` functions to use the new `canonical_stream` output format from https://github.com/mediachain/mediachain-client/pull/88

I added a cli flag so I could test catching up to a known block (`--last-known-block=QmF00...`), but plan to remove that soon.  It seems like we should be writing out the last known block ref somewhere so we can read it in after a restart.

@autoencoder, where do you think that value should get stored?  Could just spit it out to a file somewhere...
