### PR TITLE
convert binary ipfs links to base58

### DIFF
--- a/mediachain/indexer/mc_ingest.py
+++ b/mediachain/indexer/mc_ingest.py
@@ -1073,7 +1073,8 @@ def receive_blockchain_into_indexer(last_block_ref = None,
     """
     
     from mc_simpleclient import SimpleClient
-    
+    from mediachain.reader.utils import stringify_refs
+
     cur = SimpleClient()
 
     catchup = ('--disable-catchup' not in sys.argv)
@@ -1133,7 +1134,7 @@ def receive_blockchain_into_indexer(last_block_ref = None,
                 
                 print 'INSERT',rhc
                 
-                yield rh
+                yield stringify_refs(rh)
                 
             except KeyboardInterrupt:
                 raise


### PR DESCRIPTION
should prevent ES from choking on ipfs links
