### PR TITLE
get send_compactsplit_to_blockchain working again

### DIFF
--- a/mediachain/indexer/mc_ingest.py
+++ b/mediachain/indexer/mc_ingest.py
@@ -996,8 +996,12 @@ def test_image_cache(via_cli = False):
 def get_asset(hh):
     from cStringIO import StringIO
     from mediachain.reader.api import open_binary_asset
-    
-    with open_binary_asset(hh['thumbnail']) as f:
+
+    asset = open_binary_asset(hh['thumbnail'])
+    if not asset:
+        return False
+
+    with asset as f:
         image_bytes = f.read()
     
     rr = verify_img(image_bytes)

--- a/mediachain/indexer/mc_ingest.py
+++ b/mediachain/indexer/mc_ingest.py
@@ -1645,7 +1645,7 @@ def send_compactsplit_to_blockchain(path_glob = False,
     
     from mc_datasets import iter_compactsplit
     from mc_generic import set_console_title
-    from mc_normalize import apply_normalizer, normalizer_names
+    from mc_normalize import apply_normalizer_for_simpleclient, normalizer_names
     
     from mc_simpleclient import SimpleClient
     
@@ -1671,15 +1671,13 @@ def send_compactsplit_to_blockchain(path_glob = False,
     
     ## Simple:
 
-    the_iter = lambda : iter_compactsplit(path_glob, max_num = max_num)
-    
-    iter_json = apply_normalizer(iter_json,
-                                 normalizer_name,
-                                 )
-    
+    the_iter = lambda: iter_compactsplit(path_glob, max_num = max_num)
+    iter_json = apply_normalizer_for_simpleclient(the_iter, normalizer_name)
+
     cur = SimpleClient()
-    cur.write_artefacts(the_iter)        
-    
+    for x in cur.write_artefacts(iter_json):
+        print("Wrote artefact: ", x['canonical'])
+
     ## NOTE - May not reach here due to gRPC hang bug.
     
     print ('DONE ALL',)

--- a/mediachain/indexer/mc_normalize.py
+++ b/mediachain/indexer/mc_normalize.py
@@ -1877,6 +1877,27 @@ def apply_normalizer(iter_json,
         yield x
 
 
+def apply_normalizer_for_simpleclient(iter_json,
+                                      normalizer_name,
+                                      ):
+    """
+    Apply the normalizer of a given name.
+    """
+
+    assert not hasattr(iter_json, 'next'), 'Should be function that returns iterator when called, to allow restarting.'
+
+    func = normalizer_names[normalizer_name]['func']
+
+    from json import dumps
+    for c, orig in enumerate(iter_json()):
+        x = func(lambda: iter([orig])).next()
+
+        if c <= 50:
+            simple_schema_validate(x)
+
+        yield {'raw': dumps(orig), 'metadata': x}
+
+
 def apply_post_ingestion_normalizers(rr,
                                      schema_variant = 'old',
                                      ):

--- a/mediachain/indexer/mc_simpleclient.py
+++ b/mediachain/indexer/mc_simpleclient.py
@@ -62,13 +62,15 @@ class SimpleTranslator(Translator):
     
     TODO: Support multiple attribution links (multiple artists.)
     """
-    
+
+    __version__ = "0.1"
+
     @staticmethod
     def translator_id():
-        return 'SimpleTranslator/0.1'
+        return 'SimpleTranslator'
     
-    @staticmethod
-    def translate(parsed_metadata):
+    @classmethod
+    def translate(cls, parsed_metadata):
         simple_json = parsed_metadata
 
         ## Create artist Entity
@@ -90,18 +92,13 @@ class SimpleTranslator(Translator):
 
         
         ## Create thumbnail object:
-            
-        thumb_uri = parsed_metadata['img_data']
 
+        data = simple_json
         data[u'thumbnail'] = {
             u'__mediachain_asset__': True,
-            u'uri': thumb_uri
         }
 
-        
         ## Pass through rest of metadata as-is:
-        
-        data = simple_json
 
         
         ## Finish creating chain:
@@ -109,7 +106,7 @@ class SimpleTranslator(Translator):
         artwork_artefact = {
             u'__mediachain_object__': True,
             u'type': u'artefact',
-            u'meta': {'data': data}
+            u'meta': {u'data': data}
         }
 
         chain = []
@@ -159,17 +156,16 @@ class SimpleIterator(DatasetIterator):
                     if 'img_data' in metadata:
                         ft.write(mc_ingest.decode_image(metadata['img_data']))
                         ft.flush()
-                        del metadata['img_data']
+                        del metadata[u'img_data']
+                        local_assets = {u'thumbnail': {u'__mediachain_asset__': True,
+                                                       u'uri': uri_temp
+                                                       }
+                                        }
                     else:
-                        assert False,('NO_IMG_DATA',)
-                    
+                        local_assets = {}
+
                     translated = self.translator.translate(metadata)
-                    
-                    local_assets = {'thumbnail': {'__mediachain_asset__': True,
-                                                  'uri': uri_temp
-                                                  }
-                                    }
-                    
+
                     yield {'parsed': metadata,
                            'translated': translated,
                            'raw_content': raw_source,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ hyperopt==0.0.2
 #required by hyperopt:
 pymongo==3.2.2
 base58==0.2.2
-mediachain-client>=0.1.10
+mediachain-client>=0.1.13
 asteval==0.9.7
 ujson==1.33


### PR DESCRIPTION
this mostly just updates the SimpleTranslator to fit with the updated Translator interface.

It also adds an `apply_normalizer_for_simpleclient` wrapper, since the translator wants both the raw metadata and the normalized output.  So it invokes the normalizer function with a single-element generator (wrapped in a function) for each record, and yields a dictionary with `raw` and `metadata` keys as expected by the SimpleTranslator.

seems to work, but so far I've just tested with one pexels compactsplit
