### PR TITLE
if MC_IPFS_ADD_LOCAL_INT env var is set, only add to local ipfs

### DIFF
--- a/mediachain/indexer/mc_config.py
+++ b/mediachain/indexer/mc_config.py
@@ -49,6 +49,7 @@ cfg = {'1. Model Settings. NOTE - WIP. These settings are not enabled yet.':
             'MC_IPFS_URL': ('localhost', 'IPFS host.'),
             'MC_IPFS_PORT_INT': ('5001', 'IPFS port.'),
             'MC_USE_IPFS_INT':(1, 'Use IPFS for image ingestion.'),
+            'MC_IPFS_ADD_LOCAL_INT':(0, 'Do not provide ingested IPFS files to the network.')
            },
        '4. REST API Settings':
            {'MC_QUERY_CACHE_DIR':('/datasets/datasets/query_cache/', 'Location of where to store query cache.'),

--- a/mediachain/indexer/mc_simpleclient.py
+++ b/mediachain/indexer/mc_simpleclient.py
@@ -194,6 +194,7 @@ class SimpleClient(object):
                  transactor_host = mc_config.MC_TRANSACTOR_HOST,
                  transactor_port = mc_config.MC_TRANSACTOR_PORT_INT,
                  use_ipfs = mc_config.MC_USE_IPFS_INT,
+                 ipfs_add_local = mc_config.MC_IPFS_ADD_LOCAL_INT,
                  ):
         """
         """
@@ -212,6 +213,7 @@ class SimpleClient(object):
         self.transactor_host = transactor_host
         self.transactor_port = transactor_port
         self.use_ipfs = use_ipfs
+        self.ipfs_add_local = ipfs_add_local
         
         self.transactor = TransactorClient(self.transactor_host,
                                            self.transactor_port,
@@ -264,6 +266,7 @@ class SimpleClient(object):
             
             writer = Writer(self.transactor,
                             download_remote_assets=False,
+                            local_ipfs_only=self.ipfs_add_local
                             )
 
             ## Broken TODO - How to get the blockchain IDs that were generated?:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ hyperopt==0.0.2
 #required by hyperopt:
 pymongo==3.2.2
 base58==0.2.2
-mediachain-client>=0.1.13
+mediachain-client>=0.1.14
 asteval==0.9.7
 ujson==1.33


### PR DESCRIPTION
This depends on https://github.com/mediachain/mediachain-client/pull/99 - maybe we should bump the client version.

adds a new mc_confic var `MC_IPFS_ADD_LOCAL_INT` which will prevent us from actually adding anything to ipfs during ingestion.  We'll still get a hash that will resolve if we add the images, etc later.  In the future we'll probably update this to also add to the local ipfs repo but skip the network, but for now it just hashes and doesn't add at all.
